### PR TITLE
added tests for the whole donation process

### DIFF
--- a/config/config.yml.sample
+++ b/config/config.yml.sample
@@ -11,6 +11,10 @@ MEDIAWIKI_MOBILE_URL: "de.m.wikipedia.org"
 # local browser configuration
 BROWSER: "firefox"
 
+# paypal only
+PAYPAL_USERNAME: ""
+PAYPAL_PASSWORD: ""
+
 # saucelab configuration
 #SAUCE_ONDEMAND_USERNAME: "SauceLabUser"
 #SAUCE_ONDEMAND_ACCESS_KEY: "SauceLabKey"

--- a/features/sensitive.donation.feature
+++ b/features/sensitive.donation.feature
@@ -69,14 +69,14 @@ Feature: Checks wikimedia.de fundraising donation functionality in the sensitive
     And I click on the paypal back button
     Then The normal donation confirmation shows
 
-  Scenario Outline: Checks the debit donation method secound step
+  Scenario Outline: Checks the debit donation method second step
     When I click sensitive banner debit option
     And I click the banner amount100 amount option
     And I enter valid sepa bank data
     And I click the <address_type> address type option
     And I enter sensitive <address_type> address data
     And I submit the sensitive banner debit form by clicking the submit button
-    Then The debit secound step should be visible
+    Then The debit second step should be visible
     And The debit first step should not be visible
     And The finish sepa donation button should be visible
     And The company donation part should not be visible
@@ -85,7 +85,7 @@ Feature: Checks wikimedia.de fundraising donation functionality in the sensitive
     And The sepa donation part should not be visible
     And The nonsepa donation part should not be visible
     And The debit donation amount should show 100 Euro
-    And The sensitive <address_type> address data on the debit secound step should be the same
+    And The sensitive <address_type> address data on the debit second step should be the same
 
   Examples:
     | address_type |

--- a/features/sensitive.donation.feature
+++ b/features/sensitive.donation.feature
@@ -59,6 +59,16 @@ Feature: Checks wikimedia.de fundraising donation functionality in the sensitive
       | private |
       | business |
 
+  Scenario: Checks the anonymous paypal donation method and confirmation
+    When I click sensitive banner paypal option
+    And I click the banner amount100 amount option
+    And I click the anonymous address type option
+    And I submit the sensitive banner non-debit form by clicking the submit button
+    And I login with my paypal credentials
+    And I click on the paypal continue button
+    And I click on the paypal back button
+    Then The normal donation confirmation shows
+
   Scenario Outline: Checks the debit donation method secound step
     When I click sensitive banner debit option
     And I click the banner amount100 amount option

--- a/features/sensitive.donation.feature
+++ b/features/sensitive.donation.feature
@@ -69,3 +69,15 @@ Feature: Checks wikimedia.de fundraising donation functionality in the sensitive
     And The nonsepa donation part should not be visible
     And The debit donation amount should show 100 Euro
     And The sensitive address data on the debit secound step should be the same
+
+  Scenario: Checks the debit donation method and final confirmation
+    When I click sensitive banner debit option
+    And I click the banner amount100 amount option
+    And I enter valid sepa bank data
+    And I enter sensitive address data
+    And I submit the sensitive banner debit form by clicking the submit button
+    And I confirm the debit contract
+    And I confirm the notification contract
+    And I finish the sensitive banner debit form by clicking the submit button
+    Then The debit donation confirmation shows
+    And The sensitive address data on the confirmation page should be the same

--- a/features/sensitive.donation.feature
+++ b/features/sensitive.donation.feature
@@ -24,3 +24,12 @@ Feature: Checks wikimedia.de fundraising donation functionality in the sensitive
 #      | amount75 | 75,00 |
       | amount100 | 100,00 |
       | amount250 | 250,00 |
+
+  Scenario: Checks the credit card donation method
+    When I click sensitive banner credit option
+    And I click the banner amount100 amount option
+    And I enter sensitive address data
+    And I submit the sensitive banner non-debit form by clicking the submit button
+    Then The credit confirmation page shows
+    And The 100 amount value should show
+    And The cardholder should be the surname and name

--- a/features/sensitive.donation.feature
+++ b/features/sensitive.donation.feature
@@ -33,3 +33,11 @@ Feature: Checks wikimedia.de fundraising donation functionality in the sensitive
     Then The credit confirmation page shows
     And The 100 amount value should show
     And The cardholder should be the surname and name
+
+  Scenario: Checks the paypal donation method
+    When I click sensitive banner paypal option
+    And I click the banner amount100 amount option
+    And I enter sensitive address data
+    And I submit the sensitive banner non-debit form by clicking the submit button
+    Then The paypal form shows
+    And The paypal donation amount should show 100,00 Euro

--- a/features/sensitive.donation.feature
+++ b/features/sensitive.donation.feature
@@ -59,11 +59,12 @@ Feature: Checks wikimedia.de fundraising donation functionality in the sensitive
       | private |
       | business |
 
-  Scenario: Checks the debit donation method secound step
+  Scenario Outline: Checks the debit donation method secound step
     When I click sensitive banner debit option
     And I click the banner amount100 amount option
     And I enter valid sepa bank data
-    And I enter sensitive private address data
+    And I click the <address_type> address type option
+    And I enter sensitive <address_type> address data
     And I submit the sensitive banner debit form by clicking the submit button
     Then The debit secound step should be visible
     And The debit first step should not be visible
@@ -74,16 +75,27 @@ Feature: Checks wikimedia.de fundraising donation functionality in the sensitive
     And The sepa donation part should not be visible
     And The nonsepa donation part should not be visible
     And The debit donation amount should show 100 Euro
-    And The sensitive private address data on the debit secound step should be the same
+    And The sensitive <address_type> address data on the debit secound step should be the same
 
-  Scenario: Checks the debit donation method and final confirmation
+  Examples:
+    | address_type |
+    | private |
+    | business |
+
+  Scenario Outline: Checks the debit donation method and final confirmation
     When I click sensitive banner debit option
     And I click the banner amount100 amount option
     And I enter valid sepa bank data
-    And I enter sensitive private address data
+    And I click the <address_type> address type option
+    And I enter sensitive <address_type> address data
     And I submit the sensitive banner debit form by clicking the submit button
     And I confirm the debit contract
     And I confirm the notification contract
     And I finish the sensitive banner debit form by clicking the submit button
     Then The debit donation confirmation shows
-    And The sensitive private address data on the confirmation page should be the same
+    And The sensitive <address_type> address data on the confirmation page should be the same
+
+    Examples:
+      | address_type |
+      | private |
+      | business |

--- a/features/sensitive.donation.feature
+++ b/features/sensitive.donation.feature
@@ -52,3 +52,20 @@ Feature: Checks wikimedia.de fundraising donation functionality in the sensitive
     And I click on the paypal back button
     Then The normal donation confirmation shows
     And The sensitive address data on the confirmation page should be the same
+
+  Scenario: Checks the debit donation method secound step
+    When I click sensitive banner debit option
+    And I click the banner amount100 amount option
+    And I enter valid sepa bank data
+    And I enter sensitive address data
+    And I submit the sensitive banner debit form by clicking the submit button
+    Then The debit secound step should be visible
+    And The debit first step should not be visible
+    And The finish sepa donation button should be visible
+    And The company donation part should not be visible
+    And The person donation part should not be visible
+    And The address donation part should not be visible
+    And The sepa donation part should not be visible
+    And The nonsepa donation part should not be visible
+    And The debit donation amount should show 100 Euro
+    And The sensitive address data on the debit secound step should be the same

--- a/features/sensitive.donation.feature
+++ b/features/sensitive.donation.feature
@@ -10,7 +10,7 @@ Feature: Checks wikimedia.de fundraising donation functionality in the sensitive
   Scenario Outline: Checks the deposit donation method and confirmation
     When I click sensitive banner deposit option
     And I click the banner <amount> amount option
-    And I enter sensitive address data
+    And I enter sensitive private address data
     And I submit the sensitive banner non-debit form by clicking the submit button
     Then The deposit confirmation page shows
     And The confirmed amount should be <result_amount>
@@ -28,7 +28,7 @@ Feature: Checks wikimedia.de fundraising donation functionality in the sensitive
   Scenario: Checks the credit card donation method
     When I click sensitive banner credit option
     And I click the banner amount100 amount option
-    And I enter sensitive address data
+    And I enter sensitive private address data
     And I submit the sensitive banner non-debit form by clicking the submit button
     Then The credit confirmation page shows
     And The 100 amount value should show
@@ -37,7 +37,7 @@ Feature: Checks wikimedia.de fundraising donation functionality in the sensitive
   Scenario: Checks the paypal donation method
     When I click sensitive banner paypal option
     And I click the banner amount100 amount option
-    And I enter sensitive address data
+    And I enter sensitive private address data
     And I submit the sensitive banner non-debit form by clicking the submit button
     Then The paypal form shows
     And The paypal donation amount should show 100,00 Euro
@@ -45,19 +45,19 @@ Feature: Checks wikimedia.de fundraising donation functionality in the sensitive
   Scenario: Checks the paypal donation method and confirmation
     When I click sensitive banner paypal option
     And I click the banner amount100 amount option
-    And I enter sensitive address data
+    And I enter sensitive private address data
     And I submit the sensitive banner non-debit form by clicking the submit button
     And I login with my paypal credentials
     And I click on the paypal continue button
     And I click on the paypal back button
     Then The normal donation confirmation shows
-    And The sensitive address data on the confirmation page should be the same
+    And The sensitive private address data on the confirmation page should be the same
 
   Scenario: Checks the debit donation method secound step
     When I click sensitive banner debit option
     And I click the banner amount100 amount option
     And I enter valid sepa bank data
-    And I enter sensitive address data
+    And I enter sensitive private address data
     And I submit the sensitive banner debit form by clicking the submit button
     Then The debit secound step should be visible
     And The debit first step should not be visible
@@ -68,16 +68,16 @@ Feature: Checks wikimedia.de fundraising donation functionality in the sensitive
     And The sepa donation part should not be visible
     And The nonsepa donation part should not be visible
     And The debit donation amount should show 100 Euro
-    And The sensitive address data on the debit secound step should be the same
+    And The sensitive private address data on the debit secound step should be the same
 
   Scenario: Checks the debit donation method and final confirmation
     When I click sensitive banner debit option
     And I click the banner amount100 amount option
     And I enter valid sepa bank data
-    And I enter sensitive address data
+    And I enter sensitive private address data
     And I submit the sensitive banner debit form by clicking the submit button
     And I confirm the debit contract
     And I confirm the notification contract
     And I finish the sensitive banner debit form by clicking the submit button
     Then The debit donation confirmation shows
-    And The sensitive address data on the confirmation page should be the same
+    And The sensitive private address data on the confirmation page should be the same

--- a/features/sensitive.donation.feature
+++ b/features/sensitive.donation.feature
@@ -1,0 +1,26 @@
+# @licence GNU GPL v2+
+# @author Christoph Fischer <christoph.fischer@wikimedia.de>
+
+Feature: Checks wikimedia.de fundraising donation functionality in the sensitive banner for Wikipedia
+
+  Background:
+    When I am on a random Wikipedia article page and provide a B15WMDE_sensitive
+    And WMDE_BannerFullForm becomes visible
+
+  Scenario Outline: Checks the deposit donation method and confirmation
+    When I click sensitive banner deposit option
+    And I click the banner <amount> amount option
+    And I enter sensitive address data
+    And I submit the sensitive banner non-debit form by clicking the submit button
+    Then The deposit confirmation page shows
+    And The confirmed amount should be <result_amount>
+
+    Examples:
+      | amount | result_amount |
+#      | amount5 | 5,00 |
+#      | amount15 | 15,00 |
+#      | amount25 | 25,00 |
+#      | amount50 | 50,00 |
+#      | amount75 | 75,00 |
+      | amount100 | 100,00 |
+      | amount250 | 250,00 |

--- a/features/sensitive.donation.feature
+++ b/features/sensitive.donation.feature
@@ -42,16 +42,22 @@ Feature: Checks wikimedia.de fundraising donation functionality in the sensitive
     Then The paypal form shows
     And The paypal donation amount should show 100,00 Euro
 
-  Scenario: Checks the paypal donation method and confirmation
+  Scenario Outline: Checks the paypal donation method and confirmation
     When I click sensitive banner paypal option
     And I click the banner amount100 amount option
-    And I enter sensitive private address data
+    And I click the <address_type> address type option
+    And I enter sensitive <address_type> address data
     And I submit the sensitive banner non-debit form by clicking the submit button
     And I login with my paypal credentials
     And I click on the paypal continue button
     And I click on the paypal back button
     Then The normal donation confirmation shows
-    And The sensitive private address data on the confirmation page should be the same
+    And The sensitive <address_type> address data on the confirmation page should be the same
+
+    Examples:
+      | address_type |
+      | private |
+      | business |
 
   Scenario: Checks the debit donation method secound step
     When I click sensitive banner debit option

--- a/features/sensitive.donation.feature
+++ b/features/sensitive.donation.feature
@@ -41,3 +41,14 @@ Feature: Checks wikimedia.de fundraising donation functionality in the sensitive
     And I submit the sensitive banner non-debit form by clicking the submit button
     Then The paypal form shows
     And The paypal donation amount should show 100,00 Euro
+
+  Scenario: Checks the paypal donation method and confirmation
+    When I click sensitive banner paypal option
+    And I click the banner amount100 amount option
+    And I enter sensitive address data
+    And I submit the sensitive banner non-debit form by clicking the submit button
+    And I login with my paypal credentials
+    And I click on the paypal continue button
+    And I click on the paypal back button
+    Then The normal donation confirmation shows
+    And The sensitive address data on the confirmation page should be the same

--- a/features/sensitive.ui.feature
+++ b/features/sensitive.ui.feature
@@ -52,14 +52,14 @@ Feature: Checks wikimedia.de fundraising ui functionality in the sensitive banne
   Scenario: Checks if the company from field opens correctly
     When WMDE_BannerFullForm becomes visible
     And I click sensitive banner debit option
-    And I click on the address company option
+    And I click the business address type option
     Then The company donation part should be visible
     And The person donation part should not be visible
 
   Scenario: Checks if the anonymous from field works correctly
     When WMDE_BannerFullForm becomes visible
     And I click sensitive banner deposit option
-    And I click on the anonymous option
+    And I click the anonymous address type option
     Then The company donation part should not be visible
     And The person donation part should not be visible
     And The address donation part should not be visible
@@ -70,7 +70,7 @@ Feature: Checks wikimedia.de fundraising ui functionality in the sensitive banne
     When WMDE_BannerFullForm becomes visible
     And I click sensitive banner deposit option
     And I enter sensitive private address data
-    And I click on the anonymous option
+    And I click the anonymous address type option
     Then The sensitive private address data should be cleared
 
   Scenario: Checks if switching the payment method clears fields correctly

--- a/features/sensitive.ui.feature
+++ b/features/sensitive.ui.feature
@@ -69,9 +69,9 @@ Feature: Checks wikimedia.de fundraising ui functionality in the sensitive banne
   Scenario: Checks if the anonymous clears fields correctly
     When WMDE_BannerFullForm becomes visible
     And I click sensitive banner deposit option
-    And I enter sensitive address data
+    And I enter sensitive private address data
     And I click on the anonymous option
-    Then The sensitive address data should be cleared
+    Then The sensitive private address data should be cleared
 
   Scenario: Checks if switching the payment method clears fields correctly
     When WMDE_BannerFullForm becomes visible

--- a/features/sensitive.validation.feature
+++ b/features/sensitive.validation.feature
@@ -9,7 +9,7 @@ Feature: Checks wikimedia.de fundraising validation functionality in the sensiti
 
   Scenario Outline: Checks if the form validation accepts valid address data
     When I click sensitive banner deposit option
-    And I enter sensitive address data
+    And I enter sensitive private address data
     And I submit the sensitive banner non-debit form by <submit_type>
     Then The fundraising frontend shows
 
@@ -20,7 +20,7 @@ Feature: Checks wikimedia.de fundraising validation functionality in the sensiti
 
   Scenario Outline: Checks if the form validation complains with incomplete address data
     When I click sensitive banner deposit option
-    And I enter sensitive address data
+    And I enter sensitive private address data
     And I remove the <field> address data
     And I submit the sensitive banner non-debit form by clicking the submit button
     Then The address donation part should be visible
@@ -37,7 +37,7 @@ Feature: Checks wikimedia.de fundraising validation functionality in the sensiti
 
   Scenario: Checks if the form validation complains with invalid email
     When I click sensitive banner deposit option
-    And I enter sensitive address data
+    And I enter sensitive private address data
     And I enter an invalid email
     And I submit the sensitive banner non-debit form by clicking the submit button
     Then The address donation part should be visible
@@ -46,7 +46,7 @@ Feature: Checks wikimedia.de fundraising validation functionality in the sensiti
 
   Scenario: Checks if the form validation complains with invalid postcode
     When I click sensitive banner deposit option
-    And I enter sensitive address data
+    And I enter sensitive private address data
     And I enter an invalid post-code
     And I submit the sensitive banner non-debit form by clicking the submit button
     Then The address donation part should be visible
@@ -56,7 +56,7 @@ Feature: Checks wikimedia.de fundraising validation functionality in the sensiti
   Scenario: Checks if the form validation complains with invalid sepa bank data
     When I click sensitive banner debit option
     And I enter invalid sepa bank data
-    And I enter sensitive address data
+    And I enter sensitive private address data
     And I submit the sensitive banner debit form by clicking the submit button
     Then The address donation part should be visible
     And An iban error should show
@@ -66,7 +66,7 @@ Feature: Checks wikimedia.de fundraising validation functionality in the sensiti
     When I click sensitive banner debit option
     And I click on the nonsepa payment option
     And I enter invalid non-sepa bank data
-    And I enter sensitive address data
+    And I enter sensitive private address data
     And I submit the sensitive banner debit form by clicking the submit button
     Then The address donation part should be visible
     And An account-number error should show
@@ -76,5 +76,5 @@ Feature: Checks wikimedia.de fundraising validation functionality in the sensiti
     When I click sensitive banner debit option
     And I click on the nonsepa payment option
     And I enter valid non-sepa bank data
-    And I enter sensitive address data
+    And I enter sensitive private address data
     Then The sepa bank data should be filled with corresponding data

--- a/features/step_definitions/sensitive_steps.rb
+++ b/features/step_definitions/sensitive_steps.rb
@@ -140,6 +140,30 @@ Then(/^The finish donation button should not be visible$/) do
   expect(on(ArticlePage).get_element_by_id('WMDE_BannerFullForm-finish', 'button').when_not_visible).not_to be_visible
 end
 
+Then(/^The finish sepa donation button should be visible$/) do
+  expect(on(ArticlePage).get_element_by_id('WMDE_BannerFullForm-finish-sepa', 'button').when_visible).to be_visible
+end
+
+Then(/^The finish sepa donation button should not be visible$/) do
+  expect(on(ArticlePage).get_element_by_id('WMDE_BannerFullForm-finish-sepa', 'button').when_not_visible).not_to be_visible
+end
+
+Then(/^The debit first step should be visible$/) do
+  expect(on(ArticlePage).get_element_by_id('WMDE_BannerFullForm-step1', 'div').when_visible).to be_visible
+end
+
+Then(/^The debit first step should not be visible$/) do
+  expect(on(ArticlePage).get_element_by_id('WMDE_BannerFullForm-step1', 'div').when_not_visible).not_to be_visible
+end
+
+Then(/^The debit secound step should be visible$/) do
+  expect(on(ArticlePage).get_element_by_id('WMDE_BannerFullForm-step2', 'div').when_visible).to be_visible
+end
+
+Then(/^The debit secound step should not be visible$/) do
+  expect(on(ArticlePage).get_element_by_id('WMDE_BannerFullForm-step2', 'div').when_not_visible).not_to be_visible
+end
+
 Then(/^An (.*) error should show$/) do |field|
   expect(on(ArticlePage).get_validation_span_by_field(field).when_visible.class_name).to eq 'validation icon-bug'
 end
@@ -200,4 +224,15 @@ Then(/^The sensitive address data on the confirmation page should be the same$/)
   expect(on(SpendenFrontendFrontPage).span_confirm_post_code_element.when_visible.text).to eq '12345'
   expect(on(SpendenFrontendFrontPage).span_confirm_city_element.when_visible.text).to eq 'Stadtmuster'
   expect(on(SpendenFrontendFrontPage).span_confirm_mail_element.when_visible.text).to eq 'max@test.de'
+end
+
+Then(/^The debit donation amount should show (.*) Euro$/) do |result_amount|
+  expect(on(ArticlePage).span_confirm_amount_element.when_visible.text).to eq result_amount
+end
+
+Then(/^The sensitive address data on the debit secound step should be the same$/) do
+  expect(on(ArticlePage).span_confirm_salutation_element.when_visible.text).to eq 'Frau Maxe Peter'
+  expect(on(ArticlePage).span_confirm_street_element.when_visible.text).to eq 'Hansstrasse. 13'
+  expect(on(ArticlePage).span_confirm_city_element.when_visible.text).to eq '12345 Stadtmuster'
+  expect(on(ArticlePage).span_confirm_mail_element.when_visible.text).to eq 'max@test.de'
 end

--- a/features/step_definitions/sensitive_steps.rb
+++ b/features/step_definitions/sensitive_steps.rb
@@ -236,3 +236,20 @@ Then(/^The sensitive address data on the debit secound step should be the same$/
   expect(on(ArticlePage).span_confirm_city_element.when_visible.text).to eq '12345 Stadtmuster'
   expect(on(ArticlePage).span_confirm_mail_element.when_visible.text).to eq 'max@test.de'
 end
+
+
+When(/^I confirm the debit contract$/) do
+  on(ArticlePage).get_element_by_id('confirm_sepa', 'checkbox').when_visible.click
+end
+
+When(/^I confirm the notification contract$/) do
+  on(ArticlePage).get_element_by_id('confirm_shortterm', 'checkbox').when_visible.click
+end
+
+When(/^I finish the sensitive banner debit form by clicking the submit button$/) do
+  on(ArticlePage).get_element_by_id('WMDE_BannerFullForm-finish-sepa', 'button').when_visible.click
+end
+
+Then(/^The debit donation confirmation shows$/) do
+  expect(on(SpendenFrontendFrontPage).div_debit_confirmation_element.when_visible).to be_visible
+end

--- a/features/step_definitions/sensitive_steps.rb
+++ b/features/step_definitions/sensitive_steps.rb
@@ -14,7 +14,7 @@ When(/^I click on the anonymous option$/) do
   on(ArticlePage).get_element_by_id('address-type-3', 'input').when_visible.click
 end
 
-When(/^I enter sensitive address data$/) do
+When(/^I enter sensitive private address data$/) do
   on(ArticlePage).get_element_by_id('first-name', 'text_field').when_visible.send_keys 'Maxe'
   on(ArticlePage).get_element_by_id('last-name', 'text_field').when_visible.send_keys 'Peter'
   on(ArticlePage).get_element_by_id('street', 'text_field').when_visible.send_keys 'Hansstrasse. 13'
@@ -71,7 +71,7 @@ Then(/^The sepa bank data should be filled with corresponding data$/) do
   expect(on(ArticlePage).get_element_by_id('bic', 'text_field').value).to eq 'INGDDEFFXXX'
 end
 
-Then(/^The sensitive address data should be cleared$/) do
+Then(/^The sensitive private address data should be cleared$/) do
   expect(on(ArticlePage).get_element_by_id('first-name', 'text_field').value).to eq ''
   expect(on(ArticlePage).get_element_by_id('last-name', 'text_field').value).to eq ''
   expect(on(ArticlePage).get_element_by_id('street', 'text_field').value).to eq ''
@@ -218,7 +218,7 @@ Then(/^The normal donation confirmation shows$/) do
   expect(on(SpendenFrontendFrontPage).div_normal_confirmation_element.when_visible).to be_visible
 end
 
-Then(/^The sensitive address data on the confirmation page should be the same$/) do
+Then(/^The sensitive private address data on the confirmation page should be the same$/) do
   expect(on(SpendenFrontendFrontPage).span_confirm_name_element.when_visible.text).to eq 'Maxe Peter'
   expect(on(SpendenFrontendFrontPage).span_confirm_street_element.when_visible.text).to eq 'Hansstrasse. 13'
   expect(on(SpendenFrontendFrontPage).span_confirm_post_code_element.when_visible.text).to eq '12345'
@@ -230,7 +230,7 @@ Then(/^The debit donation amount should show (.*) Euro$/) do |result_amount|
   expect(on(ArticlePage).span_confirm_amount_element.when_visible.text).to eq result_amount
 end
 
-Then(/^The sensitive address data on the debit secound step should be the same$/) do
+Then(/^The sensitive private address data on the debit secound step should be the same$/) do
   expect(on(ArticlePage).span_confirm_salutation_element.when_visible.text).to eq 'Frau Maxe Peter'
   expect(on(ArticlePage).span_confirm_street_element.when_visible.text).to eq 'Hansstrasse. 13'
   expect(on(ArticlePage).span_confirm_city_element.when_visible.text).to eq '12345 Stadtmuster'

--- a/features/step_definitions/sensitive_steps.rb
+++ b/features/step_definitions/sensitive_steps.rb
@@ -163,11 +163,11 @@ Then(/^The debit first step should not be visible$/) do
   expect(on(ArticlePage).get_element_by_id('WMDE_BannerFullForm-step1', 'div').when_not_visible).not_to be_visible
 end
 
-Then(/^The debit secound step should be visible$/) do
+Then(/^The debit second step should be visible$/) do
   expect(on(ArticlePage).get_element_by_id('WMDE_BannerFullForm-step2', 'div').when_visible).to be_visible
 end
 
-Then(/^The debit secound step should not be visible$/) do
+Then(/^The debit second step should not be visible$/) do
   expect(on(ArticlePage).get_element_by_id('WMDE_BannerFullForm-step2', 'div').when_not_visible).not_to be_visible
 end
 
@@ -241,7 +241,7 @@ Then(/^The debit donation amount should show (.*) Euro$/) do |result_amount|
   expect(on(ArticlePage).span_confirm_amount_element.when_visible.text).to eq result_amount
 end
 
-Then(/^The sensitive (private|business) address data on the debit secound step should be the same$/) do |address_type|
+Then(/^The sensitive (private|business) address data on the debit second step should be the same$/) do |address_type|
   if address_type == 'private'
     expect(on(ArticlePage).span_confirm_salutation_element.when_visible.text).to eq 'Frau Maxe Peter'
   else

--- a/features/step_definitions/sensitive_steps.rb
+++ b/features/step_definitions/sensitive_steps.rb
@@ -241,8 +241,12 @@ Then(/^The debit donation amount should show (.*) Euro$/) do |result_amount|
   expect(on(ArticlePage).span_confirm_amount_element.when_visible.text).to eq result_amount
 end
 
-Then(/^The sensitive private address data on the debit secound step should be the same$/) do
-  expect(on(ArticlePage).span_confirm_salutation_element.when_visible.text).to eq 'Frau Maxe Peter'
+Then(/^The sensitive (private|business) address data on the debit secound step should be the same$/) do |address_type|
+  if address_type == 'private'
+    expect(on(ArticlePage).span_confirm_salutation_element.when_visible.text).to eq 'Frau Maxe Peter'
+  else
+    expect(on(ArticlePage).span_confirm_salutation_element.when_visible.text).to eq 'Maxe Peter GmbH & Co. KG'
+  end
   expect(on(ArticlePage).span_confirm_street_element.when_visible.text).to eq 'Hansstrasse. 13'
   expect(on(ArticlePage).span_confirm_city_element.when_visible.text).to eq '12345 Stadtmuster'
   expect(on(ArticlePage).span_confirm_mail_element.when_visible.text).to eq 'max@test.de'

--- a/features/step_definitions/sensitive_steps.rb
+++ b/features/step_definitions/sensitive_steps.rb
@@ -6,17 +6,24 @@ When(/^I click on the nonsepa payment option$/) do
   on(ArticlePage).get_element_by_id('debit-type-2', 'input').when_visible.click
 end
 
-When(/^I click on the address company option$/) do
-  on(ArticlePage).get_element_by_id('address-type-2', 'input').when_visible.click
+When(/^I click the (private|business|anonymous) address type option$/) do |address_type|
+  if address_type == 'private'
+    on(ArticlePage).get_element_by_id('address-type-1', 'input').when_visible.click
+  elsif address_type == 'business'
+    on(ArticlePage).get_element_by_id('address-type-2', 'input').when_visible.click
+  else
+    on(ArticlePage).get_element_by_id('address-type-3', 'input').when_visible.click
+  end
 end
 
-When(/^I click on the anonymous option$/) do
-  on(ArticlePage).get_element_by_id('address-type-3', 'input').when_visible.click
-end
+When(/^I enter sensitive (private|business) address data$/) do |address_type|
+  if address_type == 'private'
+    on(ArticlePage).get_element_by_id('first-name', 'text_field').when_visible.send_keys 'Maxe'
+    on(ArticlePage).get_element_by_id('last-name', 'text_field').when_visible.send_keys 'Peter'
+  else
+    on(ArticlePage).get_element_by_id('company-name', 'text_field').when_visible.send_keys 'Maxe Peter GmbH & Co. KG'
+  end
 
-When(/^I enter sensitive private address data$/) do
-  on(ArticlePage).get_element_by_id('first-name', 'text_field').when_visible.send_keys 'Maxe'
-  on(ArticlePage).get_element_by_id('last-name', 'text_field').when_visible.send_keys 'Peter'
   on(ArticlePage).get_element_by_id('street', 'text_field').when_visible.send_keys 'Hansstrasse. 13'
   on(ArticlePage).get_element_by_id('city', 'text_field').when_visible.send_keys 'Stadtmuster'
   on(ArticlePage).get_element_by_id('post-code', 'text_field').when_visible.send_keys '12345'
@@ -218,8 +225,12 @@ Then(/^The normal donation confirmation shows$/) do
   expect(on(SpendenFrontendFrontPage).div_normal_confirmation_element.when_visible).to be_visible
 end
 
-Then(/^The sensitive private address data on the confirmation page should be the same$/) do
-  expect(on(SpendenFrontendFrontPage).span_confirm_name_element.when_visible.text).to eq 'Maxe Peter'
+Then(/^The sensitive (private|business) address data on the confirmation page should be the same$/) do |address_type|
+  if address_type == 'private'
+    expect(on(SpendenFrontendFrontPage).span_confirm_name_element.when_visible.text).to eq 'Maxe Peter'
+  else
+    expect(on(SpendenFrontendFrontPage).span_confirm_name_element.when_visible.text).to eq 'Maxe Peter GmbH & Co. KG'
+  end
   expect(on(SpendenFrontendFrontPage).span_confirm_street_element.when_visible.text).to eq 'Hansstrasse. 13'
   expect(on(SpendenFrontendFrontPage).span_confirm_post_code_element.when_visible.text).to eq '12345'
   expect(on(SpendenFrontendFrontPage).span_confirm_city_element.when_visible.text).to eq 'Stadtmuster'

--- a/features/step_definitions/sensitive_steps.rb
+++ b/features/step_definitions/sensitive_steps.rb
@@ -154,5 +154,14 @@ end
 
 
 And(/^The confirmed amount should be (.*)$/) do |result_amount|
-  expect(on(SpendenFrontendFrontPage).confirmed_amount_element.text).to be == "#{result_amount}€"
+  expect(on(SpendenFrontendFrontPage).confirmed_amount_element.when_visible.text).to eq "#{result_amount}€"
+end
+
+
+Then(/^The credit confirmation page shows$/) do
+  expect(on(SpendenFrontendFrontPage).input_holder_element.when_visible).to be_visible
+end
+
+And(/^The cardholder should be the surname and name$/) do
+  expect(on(SpendenFrontendFrontPage).input_holder_element.when_visible.value).to eq 'Maxe Peter'
 end

--- a/features/step_definitions/sensitive_steps.rb
+++ b/features/step_definitions/sensitive_steps.rb
@@ -149,11 +149,11 @@ Then(/^An (.*) error should not show$/) do |field|
 end
 
 Then(/^The deposit confirmation page shows$/) do
-  expect(on(SpendenFrontendFrontPage).div_deposit_element.when_visible).to be_visible
+  expect(on(SpendenFrontendFrontPage).div_deposit_confirmation_element.when_visible).to be_visible
 end
 
 
-And(/^The confirmed amount should be (.*)$/) do |result_amount|
+Then(/^The confirmed amount should be (.*)$/) do |result_amount|
   expect(on(SpendenFrontendFrontPage).confirmed_amount_element.when_visible.text).to eq "#{result_amount}€"
 end
 
@@ -162,7 +162,7 @@ Then(/^The credit confirmation page shows$/) do
   expect(on(SpendenFrontendFrontPage).input_holder_element.when_visible).to be_visible
 end
 
-And(/^The cardholder should be the surname and name$/) do
+Then(/^The cardholder should be the surname and name$/) do
   expect(on(SpendenFrontendFrontPage).input_holder_element.when_visible.value).to eq 'Maxe Peter'
 end
 
@@ -171,6 +171,33 @@ Then(/^The paypal form shows$/) do
   expect(on(SpendenFrontendFrontPage).paypal_main_element.when_visible).to be_visible
 end
 
-And(/^The paypal donation amount should show (.*) Euro$/) do |result_amount|
+Then(/^The paypal donation amount should show (.*) Euro$/) do |result_amount|
   expect(on(SpendenFrontendFrontPage).paypal_amount_element.when_visible.text).to eq result_amount
+end
+
+
+When(/^I login with my paypal credentials$/) do
+  on(SpendenFrontendFrontPage).paypal_login_email_element.when_visible.value = ENV['PAYPAL_USERNAME']
+  on(SpendenFrontendFrontPage).paypal_login_password_element.when_visible.value = ENV['PAYPAL_PASSWORD']
+  on(SpendenFrontendFrontPage).paypal_login_button_element.when_visible.click
+end
+
+When(/^I click on the paypal continue button$/) do
+  on(SpendenFrontendFrontPage).paypal_continue_button_element.when_visible.click
+end
+
+When(/^I click on the paypal back button$/) do
+  on(SpendenFrontendFrontPage).paypal_back_element.when_visible.click
+end
+
+Then(/^The normal donation confirmation shows$/) do
+  expect(on(SpendenFrontendFrontPage).div_normal_confirmation_element.when_visible).to be_visible
+end
+
+Then(/^The sensitive address data on the confirmation page should be the same$/) do
+  expect(on(SpendenFrontendFrontPage).span_confirm_name_element.when_visible.text).to eq 'Maxe Peter'
+  expect(on(SpendenFrontendFrontPage).span_confirm_street_element.when_visible.text).to eq 'Hansstrasse. 13'
+  expect(on(SpendenFrontendFrontPage).span_confirm_post_code_element.when_visible.text).to eq '12345'
+  expect(on(SpendenFrontendFrontPage).span_confirm_city_element.when_visible.text).to eq 'Stadtmuster'
+  expect(on(SpendenFrontendFrontPage).span_confirm_mail_element.when_visible.text).to eq 'max@test.de'
 end

--- a/features/step_definitions/sensitive_steps.rb
+++ b/features/step_definitions/sensitive_steps.rb
@@ -147,3 +147,12 @@ end
 Then(/^An (.*) error should not show$/) do |field|
   expect(on(ArticlePage).get_validation_span_by_field(field).when_visible.class_name).to eq 'validation icon-ok'
 end
+
+Then(/^The deposit confirmation page shows$/) do
+  expect(on(SpendenFrontendFrontPage).div_deposit_element.when_visible).to be_visible
+end
+
+
+And(/^The confirmed amount should be (.*)$/) do |result_amount|
+  expect(on(SpendenFrontendFrontPage).confirmed_amount_element.text).to be == "#{result_amount}€"
+end

--- a/features/step_definitions/sensitive_steps.rb
+++ b/features/step_definitions/sensitive_steps.rb
@@ -165,3 +165,12 @@ end
 And(/^The cardholder should be the surname and name$/) do
   expect(on(SpendenFrontendFrontPage).input_holder_element.when_visible.value).to eq 'Maxe Peter'
 end
+
+
+Then(/^The paypal form shows$/) do
+  expect(on(SpendenFrontendFrontPage).paypal_main_element.when_visible).to be_visible
+end
+
+And(/^The paypal donation amount should show (.*) Euro$/) do |result_amount|
+  expect(on(SpendenFrontendFrontPage).paypal_amount_element.when_visible.text).to eq result_amount
+end

--- a/features/support/modules/banner_form_module.rb
+++ b/features/support/modules/banner_form_module.rb
@@ -36,6 +36,14 @@ module BannerFormModule
     element('span', xpath: ".//*[@id='#{field}']/following::span[contains(@class, 'validation')][1]")
   end
 
+  span(:span_confirm_amount, id: 'WMDE_BannerFullForm-confirm-amount')
+  span(:span_confirm_salutation, id: 'WMDE_BannerFullForm-confirm-salutation')
+  span(:span_confirm_street, id: 'WMDE_BannerFullForm-confirm-street')
+  span(:span_confirm_city,  id: 'WMDE_BannerFullForm-confirm-city')
+  span(:span_confirm_mail,  id: 'WMDE_BannerFullForm-confirm-mail')
+  span(:span_confirm_iban,  id: 'WMDE_BannerFullForm-confirm-IBAN')
+  span(:span_confirm_bic,  id: 'WMDE_BannerFullForm-confirm-BIC')
+
   def click_mobilebanner_from(banner_div_id, option)
     if (option == 'credit')
       @browser.element(id: "#{banner_div_id}_btn-cc").click

--- a/features/support/pages/spenden_frontend_front_page.rb
+++ b/features/support/pages/spenden_frontend_front_page.rb
@@ -36,6 +36,14 @@ class SpendenFrontendFrontPage
 
   text_field(:input_amount,  id: 'amount-8')
 
+  div(:paypal_main, id: 'xptContentMain')
+  span(:paypal_amount, id: 'mainTotalAmount')
+  link(:paypal_back, xpath: "//input[@id = 'CONTEXT_CGI_VAR']/following::a[1]")
+  text_field(:paypal_login_email, id: 'login_email')
+  text_field(:paypal_login_password, id: 'login_password')
+  button(:paypal_login_button, id: 'login.x')
+  button(:paypal_continue_button, id: 'continue')
+
   def get_donation_amount_element
     @browser.element(xpath: '//span[contains(@class,\'icon-ok-sign\')]/child::strong[1]')
   end

--- a/features/support/pages/spenden_frontend_front_page.rb
+++ b/features/support/pages/spenden_frontend_front_page.rb
@@ -7,6 +7,7 @@ class SpendenFrontendFrontPage
   include PageObject
 
   div(:div_spenden, id: 'wrapper')
+  div(:div_deposit, id: 'deposit-donation-confirmation')
 
   radio_button(:radio_deposit, id: 'payment-type-1')
   radio_button(:radio_credit, id: 'payment-type-2')
@@ -31,5 +32,9 @@ class SpendenFrontendFrontPage
 
   def get_donation_amount_element
     @browser.element(xpath: '//span[contains(@class,\'icon-ok-sign\')]/child::strong[1]')
+  end
+
+  def confirmed_amount_element
+    element('strong', xpath: '//p[contains(@class,\'title\')]/child::strong[1]')
   end
 end

--- a/features/support/pages/spenden_frontend_front_page.rb
+++ b/features/support/pages/spenden_frontend_front_page.rb
@@ -7,7 +7,9 @@ class SpendenFrontendFrontPage
   include PageObject
 
   div(:div_spenden, id: 'wrapper')
-  div(:div_deposit, id: 'deposit-donation-confirmation')
+  div(:div_debit_confirmation, id: 'debit-donation-confirmation')
+  div(:div_normal_confirmation, id: 'normal-donation-confirmation')
+  div(:div_deposit_confirmation, id: 'deposit-donation-confirmation')
 
   in_iframe({ id: 'micropayment-portal' }) do |mcp_frame|
     text_field(:input_holder, id: 'holder', frame: mcp_frame)
@@ -43,6 +45,12 @@ class SpendenFrontendFrontPage
   text_field(:paypal_login_password, id: 'login_password')
   button(:paypal_login_button, id: 'login.x')
   button(:paypal_continue_button, id: 'continue')
+
+  span(:span_confirm_name, id: 'confirm-name')
+  span(:span_confirm_street, id: 'confirm-street')
+  span(:span_confirm_post_code, id: 'confirm-postcode')
+  span(:span_confirm_city,  id: 'confirm-city')
+  span(:span_confirm_mail,  id: 'confirm-mail')
 
   def get_donation_amount_element
     @browser.element(xpath: '//span[contains(@class,\'icon-ok-sign\')]/child::strong[1]')

--- a/features/support/pages/spenden_frontend_front_page.rb
+++ b/features/support/pages/spenden_frontend_front_page.rb
@@ -9,6 +9,12 @@ class SpendenFrontendFrontPage
   div(:div_spenden, id: 'wrapper')
   div(:div_deposit, id: 'deposit-donation-confirmation')
 
+  in_iframe({ id: 'micropayment-portal' }) do |mcp_frame|
+    text_field(:input_holder, id: 'holder', frame: mcp_frame)
+    text_field(:input_card_number, id: 'card-number', frame: mcp_frame)
+    text_field(:input_cvc_code, id: 'cvc-code', frame: mcp_frame)
+  end
+
   radio_button(:radio_deposit, id: 'payment-type-1')
   radio_button(:radio_credit, id: 'payment-type-2')
   radio_button(:radio_debit, id: 'payment-type-3')


### PR DESCRIPTION
Basic tests for each payment method to the confirmation page. All tests could be extended with outlines to check more options. Atm there are no tests for anonymous / business data. Depending on the priorities these should be the next things to add.